### PR TITLE
Plain language page updates

### DIFF
--- a/pages/plain-language-updates.md
+++ b/pages/plain-language-updates.md
@@ -1,0 +1,112 @@
+---
+permalink: /plain-language/
+layout: default
+title: Plain language
+---
+Plain language is mandatory for [all federal government
+websites](http://www.plainlanguage.gov/). One of the aspects of
+this most people pick up on is the **plain English list,** which is
+below.
+
+This isn’t just a list of words to avoid; it’s a way of writing.
+
+U.S. government websites are for everyone. The content they contain
+should therefore be as straightforward and clear as possible.
+
+**Don’t use formal or long words when easy or short ones will do.** Use
+_buy_ instead of _purchase_, _help_ instead of _assist_, _about_ instead
+of _approximately_, and so on.
+
+We lose our users’ trust if we write using government buzzwords and
+jargon. Often, these words are too general and vague and can lead to
+misinterpretation or empty, meaningless text. We can do without these
+words:
+
+-   Agenda (unless you’re talking about a meeting)
+
+-   Advancing
+
+-   Collaborate (use *working with*)
+
+-   Combating (use *working against* or *fighting*)
+
+-   Commit/pledge (we need to be more specific — we’re either doing something or we’re not)
+
+-   Countering
+
+-   Deploy (unless you’re talking about the military or software)
+
+-   Dialogue (we speak to people)
+
+-   Disincentivize (and incentivize)
+
+-   Empower
+
+-   Facilitate (instead, say something specific about *how* you are helping)
+
+-   Focusing
+
+-   Foster (unless it's children)
+
+-   Illegals/illegal aliens (use *undocumented immigrants*)
+
+-   Impact (as a verb)
+
+-   Initiate
+
+-   Innovative (use words that describe the positive outcome of the innovation)
+
+-   Key (unless it unlocks something. A subject/thing isn’t “key” — it’s probably important)
+
+-   Land (as a verb. Only use if you’re talking about aircraft)
+
+-   Leverage (unless you use it in the financial sense)
+
+-   Overarching
+
+-   Progress (what are you actually doing?)
+
+-   Promote (unless you are talking about an ad campaign or some other marketing promotion)
+
+-   Robust
+
+-   Simple/simply (use *straightforward*, *uncomplicated*, or *clear*, or leave the descriptor out altogether)
+
+-   Streamline
+
+-   Strengthening (unless you’re referring to bridges or other structures)
+
+-   Tackling (unless you’re referring to football or another contact sport)
+
+-   Thought leader (refer to a person’s accomplishments)
+
+-   Touchpoint (mention specific system components)
+
+-   Transforming (what are you actually doing to change it?)
+
+-   User testing (unless you’re actually testing the users — otherwise, use *usability testing*)
+
+-   Utilize
+
+Avoid using figurative language — it often doesn’t say what you actually
+mean and can make your content more difficult to understand. For
+example:
+
+-   Drive (you can only drive vehicles, not schemes or people)
+
+-   Drive out (unless it's cattle)
+
+-   Going forward (unless you’re giving directions)
+
+-   In order to (this is superfluous — don’t use it)
+
+-   One-stop shop (we’re the government, not a big box store)
+
+In most cases, you can avoid these figures of speech by describing what
+you’re actually doing. Be open and specific.
+
+Write conversationally. Picture your audience and write as if you were
+talking to them one-on-one and with the authority of someone who can
+actively help.
+
+For a comprehensive explanation of plain language, please check out the Federal (Plain Language Guidelines)[ http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh].

--- a/pages/plain-language-updates.md
+++ b/pages/plain-language-updates.md
@@ -109,4 +109,4 @@ Write conversationally. Picture your audience and write as if you were
 talking to them one-on-one and with the authority of someone who can
 actively help.
 
-For a comprehensive explanation of plain language, please check out the Federal [Plain Language Guidelines] (http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh).
+For a comprehensive explanation of plain language, please check out the [Federal Plain Language Guidelines] (http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh).

--- a/pages/plain-language-updates.md
+++ b/pages/plain-language-updates.md
@@ -109,4 +109,4 @@ Write conversationally. Picture your audience and write as if you were
 talking to them one-on-one and with the authority of someone who can
 actively help.
 
-For a comprehensive explanation of plain language, please check out the Federal (Plain Language Guidelines)[ http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh].
+For a comprehensive explanation of plain language, please check out the Federal [Plain Language Guidelines] (http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh).

--- a/pages/references-update.md
+++ b/pages/references-update.md
@@ -1,0 +1,22 @@
+---
+permalink: /references/
+layout: default
+title: References
+---
+We adapted this guide from [GOV.UK](https://www.gov.uk/)’s
+excellent work, and we’d like to thank their content team for
+championing plain language and information accessibility.
+
+As we created this guide, we also referred to these resources:
+
+-   [The Associated Press Stylebook](https://www.apstylebook.com/)
+
+-   [The U.S. Government Publishing Office](http://www.gpo.gov/)
+
+-   [Conscious Style Guide](http://consciousstyleguide.com/)
+
+-   [Plain Language Action and Information Network](http://www.plainlanguage.gov/)
+
+
+Can’t find something you’re looking for? Create a new section — this
+guide is a living document.


### PR DESCRIPTION
Per the request of Katherine Spivey (Acting Communications Lead of ITS Portfolio Outreach Division), I'd like to add a link to this plainlanguage.gov page at the bottom of our Plain Language section:

For a comprehensive explanation of plain language, please read the Federal Plain Language Guidelines (link to http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh). 
