### PR TITLE
In the page layout, move the sidebar partial below the main-content area

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,17 +15,17 @@
           {% endif %}
           <h1 class="site-title"><a class="title-link" href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
         </div>
-        
+
       </header>
 
       <div class="wrap content">
-
-        {% include sidebar.html %}
 
         <section id="main" class="main-content" role="main">
           <h1>{{ page.title }}</h1>
           {{ content }}
         </section>
+
+        {% include sidebar.html %}
 
       </div><!-- /.wrap content -->
 


### PR DESCRIPTION
When the site is viewed on a mobile device, the page collapses so that the `{% include sidebar.html %}` column is always above the page's **.main-content** element. This makes every page, above the fold, look the same on a mobile device, forcing the user to scroll several lengths to get to the page's actual content.

Since the sidebar and .main-content element  have specific float styles, the visual layout of the multi-column grid remains the same, even of the sidebar-include is moved _below_ the content area:

``` html
      <div class="wrap content">

        <section id="main" class="main-content" role="main">
          <h1>{{ page.title }}</h1>
          {{ content }}
        </section>

        {% include sidebar.html %}

      </div><!-- /.wrap content -->
```

However, on mobile, the page's main-content now gets priority in the layout (new version is on the **left**):

![image](https://cloud.githubusercontent.com/assets/121520/9215085/cb833d7e-405a-11e5-9414-536f4bf24ee1.png)

This change might also help with SEO, as it moves the page content higher up semantically, but who knows with Google's magic these days...
