### PR TITLE
Link to 18F Open Source Style Guide

### DIFF
--- a/pages/legal-and-technical-content.md
+++ b/pages/legal-and-technical-content.md
@@ -13,3 +13,7 @@ always explain it in plain language.
 
 Use technical terms when necessary. They're not jargon — you
 need only explain what they mean the first time you reference them.
+
+If you are publishing the source code for a project, the
+[18F Open Source Style Guide](https://pages.18f.gov/open-source-guide/)
+can help you make the project easy to use and understand.


### PR DESCRIPTION
Add paragraph about publishing source code and link to 18F Open Source Style Guide to “Publishing Legal and Technical Content” section. Addresses https://github.com/18F/content-guide/issues/89 
