### PR TITLE
Plain language guidance and links

### DIFF
--- a/_pages/capitalization.md
+++ b/_pages/capitalization.md
@@ -3,14 +3,14 @@ title: Capitalization
 ---
 **Follow a consistent capitalization scheme**. Creating trustworthy internal and external communications relies, to a large extent, on the content’s consistency. Inconsistent spellings and capitalizations undermine your narrative authority. We follow these capitalization guidelines:
 
-- Don't capitalize “agile,” unless it is the first word of a sentence
-- Don't capitalize “open source,” unless it is the first word of a sentence
-- Don't capitalize “federal” or “government”
+- Don't capitalize _agile,_ unless it is the first word of a sentence
+- Don't capitalize _open source,_ unless it is the first word of a sentence
+- Don't capitalize _federal_ or _government_
 
 When you're deciding whether to capitalize noun phrases, keep in mind that in English, title case is often a marker of formality. Using it judiciously can help clarify that you're speaking about a specific, official thing (such as a form, office, or person). Overuse can cause users stress by implying formality or officialness where it doesn't exist. For instance:
 
 - It makes sense to capitalize the phrase "Form 1040, U.S. Individual Income Tax Return" because you want users to know the exact, official title of that specific form.
-- It could confuse users to capitalize "income taxes" or "income tax forms," because those phrases could refer to any number of possible forms.
+- It could confuse users to capitalize _income taxes_ or _income tax forms_, because those phrases could refer to any number of possible forms.
 
 See additional capitalization rules in the [Specific words and phrases](https://pages.18f.gov/content-guide/specific-words-and-phrases/)
 section.
@@ -19,8 +19,8 @@ section.
 
 Headlines, page titles, subheads and similar content should follow sentence case, and should not include a trailing colon. For example:
 
-*Making sense of Washington’s tech landscape*
+_Making sense of Washington’s tech landscape_
 
-*Privileges and responsibilities*
+_Privileges and responsibilities_
 
 See also: information about [optimizing headings](../optimize-headings-and-titles/).

--- a/_pages/conscious-style.md
+++ b/_pages/conscious-style.md
@@ -3,8 +3,8 @@ title: Conscious style
 ---
 We follow the [Conscious Style Guide](http://consciousstyleguide.com/) because we are inclusive of all users.
 
-- Age: We prefer **older person** or **senior** to elderly.
+- Age: We prefer _older person_ or _senior_ to elderly.
 
-- Nationality: Avoid using **citizen** as a generic term for people who live inside the U.S. Many government programs serve non-citizens and individuals with a wide range of immigration and visa statuses. Use **public** when possible.
+- Nationality: Avoid using _citizen_ as a generic term for people who live inside the U.S. Many government programs serve non-citizens and individuals with a wide range of immigration and visa statuses. Use _public_ when possible.
 
-- Gender: Ensure text is gender neutral, wherever possible. Use **they**, **them**, and **their**. Avoid words and phrases that indicate gender bias — for example, lengthy and irrelevant descriptions of appearance.
+- Gender: Ensure text is gender neutral, wherever possible. Use _they_, _them_, and _their_. Avoid words and phrases that indicate gender bias — for example, lengthy and irrelevant descriptions of appearance.

--- a/_pages/plain-language.md
+++ b/_pages/plain-language.md
@@ -24,34 +24,34 @@ Try to avoid these words when you can:
 
 - Agenda (unless you’re talking about a meeting)
 - Advancing
-- Collaborate (use *working with*)
-- Combating (use *working against* or *fighting*)
+- Collaborate (use _working with_)
+- Combating (use _working against_ or _fighting_)
 - Commit/pledge (we need to be more specific — we’re either doing something or we’re not)
-- Countering (use *answering* or *responding*)
+- Countering (use _answering_ or _responding_)
 - Deliver (pizzas, mail, and services are delivered — not abstract concepts like improvements or priorities)
 - Deploy (unless you’re talking about the military or software)
 - Dialogue (we speak to people)
 - Disincentivize (and incentivize)
 - Empower
-- Execute (use *run* or *do*)
-- Facilitate (instead, say something specific about *how* you are helping)
+- Execute (use _run_ or _do_)
+- Facilitate (instead, say something specific about _how_ you are helping)
 - Focusing
 - Foster (unless it's children)
-- Illegals/illegal aliens (use *undocumented immigrants*)
+- Illegals/illegal aliens (use _undocumented immigrants_)
 - Impact (as a verb)
-- Initiate (use *start*)
+- Initiate (use _start_)
 - Innovative (use words that describe the positive outcome of the innovation)
 - In order to (superfluous — don’t use it)
-- Key (unless it unlocks something — otherwise, use *important* or omit)
+- Key (unless it unlocks something — otherwise, use _important_ or omit)
 - Land (as a verb only use if you’re talking about aircraft)
 - Leverage (unless you use it in the financial sense)
-- Liaise (use *collaborate* or *work with*)
-- Modify (use *change* instead)
+- Liaise (use _collaborate_ or _work with_)
+- Modify (use _change_ instead)
 - Overarching
 - Progress (what are you actually doing?)
 - Promote (unless you are talking about an ad campaign or some other marketing promotion)
 - Robust
-- Simple/simply (use *straightforward*, *uncomplicated*, or *clear*, or leave the descriptor out altogether)
+- Simple/simply (use _straightforward_, _uncomplicated_, or _clear_, or leave the descriptor out altogether)
 - Slimming down (processes don’t diet)
 - Streamline
 - Strengthening (unless you’re referring to bridges or other structures)
@@ -59,8 +59,8 @@ Try to avoid these words when you can:
 - Thought leader (refer to a person’s accomplishments)
 - Touchpoint (mention specific system components)
 - Transforming (what are you actually doing to change it?)
-- User testing (use *user research* or *usability testing*)
-- Utilize (use *use*)
+- User testing (use _user research_ or _usability testing_)
+- Utilize (use _use_)
 
 For more about plain language, these guidelines and lists are great resources: 
 

--- a/_pages/plain-language.md
+++ b/_pages/plain-language.md
@@ -66,5 +66,6 @@ For more about plain language, these guidelines and lists are great resources:
 
 * [Federal Plain Language Guidelines](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/TOC.cfm)
 * [Avoiding legal, foreign, and technical jargon](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/writeNoJargon.cfm)
+* King County: [Shorter, simpler words](http://www.kingcounty.gov/exec/styleguide/concisewriting/simplerwords.aspx)
 * Gov.uk: [Plain English](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english) and [Words to avoid](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#words-to-avoid)
 

--- a/_pages/plain-language.md
+++ b/_pages/plain-language.md
@@ -1,38 +1,52 @@
 ---
 title: Plain language
 ---
-[Plain language](http://www.plainlanguage.gov/) is mandatory for all federal government websites. One of the aspects of this most people pick up on is the **plain English list,** which is below.
+U.S. government websites are for everyone. The content they contain should be as straightforward as possible. One of the best ways to make content clear and usable is to use **plain language**. When we use words people understand, our content is more findable, accessible, and inclusive. [Plain language](http://www.plainlanguage.gov/) is also mandatory for all federal government websites.
 
-This isn’t just a list of words to avoid; it’s a way of writing.
+When we use jargon in our writing, we risk losing users’ trust. Government, legal, business jargon are often vague or unfamiliar to users, and can lead to misinterpretation.
 
-U.S. government websites are for everyone. The content they contain should therefore be as straightforward and clear as possible.
+Another temptation that can hurt readability is figurative language: it often doesn’t say what you actually mean, and can make your content more difficult to understand. For example:
+
+- Drive (you can only drive vehicles, not schemes or people)
+- Drive out (unless it's cattle)
+- Going forward (unless you’re giving directions)
+- One-stop shop (we’re the government, not a big box store)
+
+In most cases, you can avoid these figures of speech by describing what you’re actually doing. Be open and specific.
+
+If you're struggling to use plain language, try writing conversationally. Picture your audience and write as if you were talking to them one-on-one, with the authority of someone who can actively help.
 
 **Don’t use formal or long words when easy or short ones will do.** Use _buy_ instead of _purchase_, _help_ instead of _assist_, _about_ instead of _approximately_, and so on.
 
-We lose our users’ trust if we write using government buzzwords and jargon. Often, these words are too general and vague and can lead to misinterpretation or empty, meaningless text. We can do without these words:
+**Plain English lists** can help spot problem words and consider alternatives, but keep in mind that plain language is more than just a list of words to avoid — it’s a way of writing.
+
+Try to avoid these words when you can:
 
 - Agenda (unless you’re talking about a meeting)
 - Advancing
 - Collaborate (use *working with*)
 - Combating (use *working against* or *fighting*)
 - Commit/pledge (we need to be more specific — we’re either doing something or we’re not)
-- Countering
-- Deliver (pizzas, mail, and services are delivered - not abstract concepts like improvements or priorities)
+- Countering (use *answering* or *responding*)
+- Deliver (pizzas, mail, and services are delivered — not abstract concepts like improvements or priorities)
 - Deploy (unless you’re talking about the military or software)
 - Dialogue (we speak to people)
 - Disincentivize (and incentivize)
 - Empower
+- Execute (use *run* or *do*)
 - Facilitate (instead, say something specific about *how* you are helping)
 - Focusing
 - Foster (unless it's children)
 - Illegals/illegal aliens (use *undocumented immigrants*)
 - Impact (as a verb)
-- Initiate
+- Initiate (use *start*)
 - Innovative (use words that describe the positive outcome of the innovation)
-- Key (unless it unlocks something. A subject/thing isn’t “key” — it’s probably important)
+- In order to (superfluous — don’t use it)
+- Key (unless it unlocks something — otherwise, use *important* or omit)
 - Land (as a verb only use if you’re talking about aircraft)
 - Leverage (unless you use it in the financial sense)
-- Liaise
+- Liaise (use *collaborate* or *work with*)
+- Modify (use *change* instead)
 - Overarching
 - Progress (what are you actually doing?)
 - Promote (unless you are talking about an ad campaign or some other marketing promotion)
@@ -45,19 +59,12 @@ We lose our users’ trust if we write using government buzzwords and jargon. Of
 - Thought leader (refer to a person’s accomplishments)
 - Touchpoint (mention specific system components)
 - Transforming (what are you actually doing to change it?)
-- User testing (unless you’re actually testing the users — otherwise, use *usability testing*)
-- Utilize
+- User testing (use *user research* or *usability testing*)
+- Utilize (use *use*)
 
-Avoid using figurative language — it often doesn’t say what you actually mean and can make your content more difficult to understand. For example:
+For more about plain language, these guidelines and lists are great resources: 
 
-- Drive (you can only drive vehicles, not schemes or people)
-- Drive out (unless it's cattle)
-- Going forward (unless you’re giving directions)
-- In order to (superfluous — don’t use it)
-- One-stop shop (we’re the government, not a big box store)
+* [Federal Plain Language Guidelines](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/TOC.cfm)
+* [Avoiding legal, foreign, and technical jargon](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/writeNoJargon.cfm)
+* Gov.uk: [Plain English](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english) and [Words to avoid](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#words-to-avoid)
 
-In most cases, you can avoid these figures of speech by describing what you’re actually doing. Be open and specific.
-
-Write conversationally. Picture your audience and write as if you were talking to them one-on-one and with the authority of someone who can actively help.
-
-For a comprehensive explanation of plain language, please check out the [Federal Plain Language Guidelines](http://www.plainlanguage.gov/howto/guidelines/FederalPLGuidelines/index.cfm?CFID=3861979&CFTOKEN=cbb4a39d1e0a1042-298391FB-E153-0A73-341ABEDF77AE21AF&jsessionid=83029D534F870FEEDAB242987DF50ECB.chh).

--- a/_pages/specific-words-and-phrases.md
+++ b/_pages/specific-words-and-phrases.md
@@ -9,7 +9,7 @@ Below are rules for how 18F uses common words and phrases, in alphabetical order
 
 **A**
 
-- **ages**, avoid hyphens in ages unless it clarifies the text. For example, *a group of 10 18-year-old White House tourists*
+- **ages**, avoid hyphens in ages unless it clarifies the text. For example, _a group of 10 18-year-old White House tourists_
 - **agile**
 - **a.m.**
 - **and**, never & or +, unless part of an official title. For example, *D.C. Tech Lady Hackathon + Training Day*
@@ -26,7 +26,7 @@ Below are rules for how 18F uses common words and phrases, in alphabetical order
 
 **D**
 
-- **D.C.**, not "DC"
+- **D.C.**, not _DC_
 - **digital coalition**
 - **Draft U.S. Web Design Standards** on first use and **Draft Standards** on subsequent references
 - **drop-down** when used as an adjective. For example, *drop-down menu.* **drop down** when used as a noun. For example, *an option from the drop down.* Never "dropdown."


### PR DESCRIPTION
This PR attempts to resolve issues #46, #77, and #78:
- Add links to external plain language guidelines and lists
- Restructure the page slightly to bring some of the great guidance that was sitting after the word list up to the intro section
- Added some positive, user-centered arguments _for_ plain language to offset our excellent denunciation of jargon
- Added a number of alternates to the "bad word" list, to help folks struggling for alternate options

This is a bigger change, so let's make sure we get at least a few 👍  from the Content Guild and/or xd-content team before merging. This may also need (and I welcome!) another edit pass.
