### PR TITLE
Minor correction to the Capitalization page

### DIFF
--- a/_pages/capitalization.md
+++ b/_pages/capitalization.md
@@ -25,6 +25,7 @@ Don’t capitalize personal titles unless they precede a name. For example, *the
 Headlines, page titles, subheads and similar content should follow sentence case, and should not include a trailing colon. For example:
 
 > _Making sense of Washington’s tech landscape_
+
 > _Privileges and responsibilities_
 
 See also: information about [optimizing headings](../optimize-headings-and-titles/).


### PR DESCRIPTION
These two examples should each be on their own line, so they need a line of whitespace between them in the Markdown source.
