### PR TITLE
Continuous Integration/Tests setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+- 2.1.5
+cache: bundler
+script: ./go ci_build

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'go_script'
 
 group :jekyll_plugins do
   gem 'guides_style_18f'
+  gem 'html-proofer'
   gem 'jekyll_pages_api_search'
   gem 'jekyll-redirect-from'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.4.0)
     colorator (0.1)
+    colored (1.2)
+    ethon (0.9.0)
+      ffi (>= 1.3.0)
     ffi (1.9.10)
     go_script (0.1.6)
       bundler (~> 1.10)
@@ -12,7 +22,17 @@ GEM
       jekyll_pages_api_search
       rouge
       sass
+    html-proofer (3.0.6)
+      activesupport (~> 4.2)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
     htmlentities (4.3.4)
+    i18n (0.7.0)
     jekyll (3.1.2)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
@@ -34,18 +54,32 @@ GEM
     jekyll_pages_api_search (0.4.3)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
+    json (1.8.3)
     kramdown (1.9.0)
     liquid (3.0.6)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.5)
+    mini_portile2 (2.1.0)
+    minitest (5.9.0)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    parallel (1.9.0)
+    pkg-config (1.1.7)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.21)
+    thread_safe (0.3.5)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    yell (2.0.6)
 
 PLATFORMS
   ruby
@@ -53,6 +87,7 @@ PLATFORMS
 DEPENDENCIES
   go_script
   guides_style_18f
+  html-proofer
   jekyll
   jekyll-redirect-from
   jekyll_pages_api_search

--- a/go
+++ b/go
@@ -51,4 +51,15 @@ def_command :build, 'Build the site' do |args|
   build_jekyll args
 end
 
+def_command :ci_build, 'Run the CI tests' do |args|
+  build_jekyll
+  require 'html-proofer'
+  HTMLProofer.check_directory('./_site',
+    disable_external: true,
+    url_ignore: [
+      /group\.calendar\.google\.com/
+    ]
+  ).run
+end
+
 execute_command ARGV


### PR DESCRIPTION
Add HTML Proofer, a `ci_build` command for `go`, and a `.travis.yml` file that calls `go ci_build` for a Travis Continuous Integration test.

All of which adds up to each PR running a set of basic checks and then GitHub displaying a pass/fail for that PR, so if we break links in a commit, it'll warn us of that. Running `go ci_build` locally will run the same tests, so it should be easy to see locally whether or not we've broken something.
