### PR TITLE
Citizens public

### DIFF
--- a/_pages/our-approach/address-the-user.md
+++ b/_pages/our-approach/address-the-user.md
@@ -3,12 +3,12 @@ title: Address the user
 ---
 Address the user as _you_ whenever possible.
 
-Content on government sites often makes a direct appeal to the public and businesses to get involved or take action. For example, *You can contact 18F at this email address* or *Learn more about starting your MyRA account*.
+Content on government sites often makes a direct appeal to the public and businesses to get involved or take action. For example:
 
-If you’re creating content that addresses multiple users—such as a patient and their caregiver—address the primary user as “you” and the secondary users by their roles or titles.
+> You can contact 18F at [mailto:18F@gsa.gov](18F@gsa.gov)
 
-## How to talk about the public
+> Learn more about starting your MyRA account
 
-How you refer to the public is largely dependent on context. Feel free to choose from any of the words on this list: people, the public, users, or folks.
+If you’re creating content for multiple users—such as patients and their caregivers—address the primary user as _you_ and the secondary users by their roles or titles.
 
-We recommend against using the word [citizens](https://pages.18f.gov/content-guide/conscious-style/#nationality) this way. Not everyone who uses a government website is a citizen, and we shouldn’t assume that in our prose. Use _citizens_ to specify information related to U.S. citizenship — for example, describing who is eligible to vote in federal elections.
+We recommend against using the word _citizens_ when talking about the public. See the [conscious style](https://pages.18f.gov/content-guide/conscious-style/#nationality) section for further guidance.

--- a/_pages/our-approach/address-the-user.md
+++ b/_pages/our-approach/address-the-user.md
@@ -1,14 +1,15 @@
 ---
 title: Address the user
 ---
-Address the user as _you_ whenever possible.
 
-Content on government sites often makes a direct appeal to the public and businesses to get involved or take action. For example:
+Content on government sites often makes a direct appeal to the public to get involved or take action.
 
-> You can contact 18F at [mailto:18F@gsa.gov](18F@gsa.gov)
+Address the user as _you_ whenever possible. For example:
+
+> You can contact 18F at [18F@gsa.gov](mailto:18F@gsa.gov) or find us on [Twitter](https://twitter.com/18f).
 
 > Learn more about starting your MyRA account
 
-If you’re creating content for multiple users—such as patients and their caregivers—address the primary user as _you_ and the secondary users by their roles or titles.
+If you’re creating content for multiple users—such as patients and their caregivers—address the primary user as _you_ and refer to secondary users by their roles or titles.
 
 We recommend against using the word _citizens_ when talking about the public. See the [conscious style](https://pages.18f.gov/content-guide/conscious-style/#nationality) section for further guidance.

--- a/_pages/our-approach/address-the-user.md
+++ b/_pages/our-approach/address-the-user.md
@@ -6,9 +6,9 @@ Content on government sites often makes a direct appeal to the public to get inv
 
 Address the user as _you_ whenever possible. For example:
 
-> You can contact 18F at [18F@gsa.gov](mailto:18F@gsa.gov) or find us on [Twitter](https://twitter.com/18f).
+> You can email us at [18F@gsa.gov](mailto:18F@gsa.gov) or find us on [Twitter](https://twitter.com/18f).
 
-> Learn more about starting your MyRA account
+> Learn more about starting your MyRA account.
 
 If you’re creating content for multiple users—such as patients and their caregivers—address the primary user as _you_ and refer to secondary users by their roles or titles.
 

--- a/_pages/our-style/conscious-style.md
+++ b/_pages/our-style/conscious-style.md
@@ -9,7 +9,18 @@ We prefer _older person_ or _senior_ to _elderly_.
 
 ## Nationality
 
-Avoid using _citizen_ as a generic term for people who live inside the U.S. Many government programs serve non-citizens and individuals with a wide range of immigration and visa statuses. Use _public_ when possible.
+Avoid using _citizen_ as a generic term for people who live within the U.S. Many government programs serve non-citizens and individuals with a wide range of immigration and visa statuses.
+
+How you refer to the public is largely dependent on context. Feel free to choose from any of these words:
+
+* People
+* The public
+* Users
+* Folks
+
+Be as specific as possible. Depending on the topic, you may want to say something like "People who need healthcare" or "People who need to access government services online."
+
+Use _citizens_ for information related to U.S. citizenship, such as describing who is eligible to vote in federal elections.
 
 ## Gender
 

--- a/_pages/our-style/conscious-style.md
+++ b/_pages/our-style/conscious-style.md
@@ -20,7 +20,10 @@ How you refer to the public is largely dependent on context. Feel free to choose
 
 Be as specific as possible. Depending on the situation, you may want to say something like "People who need healthcare" or "People who need to access government services online."
 
-Use _citizens_ for information related to U.S. citizenship, such as describing who is eligible to vote in federal elections.
+Use _citizens_ for information related to U.S. citizenship, for example, when describing who is eligible to vote in federal elections.
+
+Be careful with _Americans_ or _the American public_. These terms are [ambiguous](https://en.wikipedia.org/wiki/Names_for_United_States_citizens) and are often used as synonyms for _citizens_. In most cases, _the public_ is equally clear and more inclusive. That said, referring to Americans and America can be useful if you want to inspire readers or take a more patriotic tone.
+
 
 ## Gender
 

--- a/_pages/our-style/conscious-style.md
+++ b/_pages/our-style/conscious-style.md
@@ -22,7 +22,7 @@ Be as specific as possible. Depending on the situation, you may want to say some
 
 Use _citizens_ for information related to U.S. citizenship, for example, when describing who is eligible to vote in federal elections.
 
-Be careful with _Americans_ or _the American public_. These terms are [ambiguous](https://en.wikipedia.org/wiki/Names_for_United_States_citizens) and are often used as synonyms for _citizens_. In most cases, _the public_ is equally clear and more inclusive. That said, referring to Americans and America can be useful if you want to inspire readers or take a more patriotic tone.
+Be careful with _Americans_ or _the American public_. These terms are [ambiguous](https://en.wikipedia.org/wiki/Names_for_United_States_citizens) and are often used as synonyms for _citizens_. In most cases, _the public_ is equally clear and more inclusive. That said, referring to _Americans_ or _the American people_ can be useful if you want to inspire readers or take a more patriotic tone.
 
 
 ## Gender

--- a/_pages/our-style/conscious-style.md
+++ b/_pages/our-style/conscious-style.md
@@ -9,7 +9,7 @@ We prefer _older person_ or _senior_ to _elderly_.
 
 ## Nationality
 
-Avoid using _citizen_ as a generic term for people who live within the U.S. Many government programs serve non-citizens and individuals with a wide range of immigration and visa statuses.
+Avoid using _citizen_ as a generic term for people who live in the United States. Many government programs serve non-citizens and individuals with a wide range of immigration and visa statuses.
 
 How you refer to the public is largely dependent on context. Feel free to choose from any of these words:
 
@@ -18,7 +18,7 @@ How you refer to the public is largely dependent on context. Feel free to choose
 * Users
 * Folks
 
-Be as specific as possible. Depending on the topic, you may want to say something like "People who need healthcare" or "People who need to access government services online."
+Be as specific as possible. Depending on the situation, you may want to say something like "People who need healthcare" or "People who need to access government services online."
 
 Use _citizens_ for information related to U.S. citizenship, such as describing who is eligible to vote in federal elections.
 


### PR DESCRIPTION
Fixes #128 - Moves main entry about inclusive language to one combined section, adds details about _Americans_ and _the American public_.

cc @coreycaitlin for :eyes: as I am doing my best to write out her recommendation
