### PR TITLE
fix {{ baseurl }} -> {{ site.baseurl }}

### DIFF
--- a/_pages/content-types/urls-and-filenames.md
+++ b/_pages/content-types/urls-and-filenames.md
@@ -357,8 +357,8 @@ This has an added benefit of improving search results for sighted users.
 In some situations, descriptive links may be overly verbose or redundant for
 sighted users. Here’s an example from the [betaFEC site][]:
 
-<a href="{{ baseurl }}/assets/img/betaFEC.png">
-  <img src="{{ baseurl }}/assets/img/betaFEC.png" alt="betaFEC screenshot">
+<a href="{{ site.baseurl }}/assets/img/betaFEC.png">
+  <img src="{{ site.baseurl }}/assets/img/betaFEC.png" alt="betaFEC screenshot">
 </a>
 
 Here the *Learn more* link is appropriate for sighted users, but it may be


### PR DESCRIPTION
Oops, the betaFEC screenshot is broken on the [live site](https://pages.18f.gov/content-guide/urls-and-filenames/):

> <img width="570" alt="screen shot 2016-09-22 at 5 17 28 pm" src="https://cloud.githubusercontent.com/assets/124687/18768086/85de9690-80e8-11e6-8312-9dbd61ca812f.png">

This should fix it, I hope!
