### PR TITLE
Add rouge syntax highlighting CSS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,7 @@
 
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/stylesheets/reset.css">
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/stylesheets/screen.css">
+  <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/stylesheets/pygments-css-github.css">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 

--- a/stylesheets/pygments-css-github.css
+++ b/stylesheets/pygments-css-github.css
@@ -1,0 +1,63 @@
+/* This is based on https://github.com/richleland/pygments-css. */
+
+.highlighter-rouge .hll { background-color: #ffffcc }
+.highlighter-rouge .c { color: #999988; font-style: italic } /* Comment */
+.highlighter-rouge .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlighter-rouge .k { color: #000000; font-weight: bold } /* Keyword */
+.highlighter-rouge .o { color: #000000; font-weight: bold } /* Operator */
+.highlighter-rouge .cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.highlighter-rouge .cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.highlighter-rouge .c1 { color: #999988; font-style: italic } /* Comment.Single */
+.highlighter-rouge .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlighter-rouge .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlighter-rouge .ge { color: #000000; font-style: italic } /* Generic.Emph */
+.highlighter-rouge .gr { color: #aa0000 } /* Generic.Error */
+.highlighter-rouge .gh { color: #999999 } /* Generic.Heading */
+.highlighter-rouge .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlighter-rouge .go { color: #888888 } /* Generic.Output */
+.highlighter-rouge .gp { color: #555555 } /* Generic.Prompt */
+.highlighter-rouge .gs { font-weight: bold } /* Generic.Strong */
+.highlighter-rouge .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlighter-rouge .gt { color: #aa0000 } /* Generic.Traceback */
+.highlighter-rouge .kc { color: #000000; font-weight: bold } /* Keyword.Constant */
+.highlighter-rouge .kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
+.highlighter-rouge .kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
+.highlighter-rouge .kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
+.highlighter-rouge .kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
+.highlighter-rouge .kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.highlighter-rouge .m { color: #009999 } /* Literal.Number */
+.highlighter-rouge .s { color: #d01040 } /* Literal.String */
+.highlighter-rouge .na { color: #008080 } /* Name.Attribute */
+.highlighter-rouge .nb { color: #0086B3 } /* Name.Builtin */
+.highlighter-rouge .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlighter-rouge .no { color: #008080 } /* Name.Constant */
+.highlighter-rouge .nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
+.highlighter-rouge .ni { color: #800080 } /* Name.Entity */
+.highlighter-rouge .ne { color: #990000; font-weight: bold } /* Name.Exception */
+.highlighter-rouge .nf { color: #990000; font-weight: bold } /* Name.Function */
+.highlighter-rouge .nl { color: #990000; font-weight: bold } /* Name.Label */
+.highlighter-rouge .nn { color: #555555 } /* Name.Namespace */
+.highlighter-rouge .nt { color: #000080 } /* Name.Tag */
+.highlighter-rouge .nv { color: #008080 } /* Name.Variable */
+.highlighter-rouge .ow { color: #000000; font-weight: bold } /* Operator.Word */
+.highlighter-rouge .w { color: #bbbbbb } /* Text.Whitespace */
+.highlighter-rouge .mf { color: #009999 } /* Literal.Number.Float */
+.highlighter-rouge .mh { color: #009999 } /* Literal.Number.Hex */
+.highlighter-rouge .mi { color: #009999 } /* Literal.Number.Integer */
+.highlighter-rouge .mo { color: #009999 } /* Literal.Number.Oct */
+.highlighter-rouge .sb { color: #d01040 } /* Literal.String.Backtick */
+.highlighter-rouge .sc { color: #d01040 } /* Literal.String.Char */
+.highlighter-rouge .sd { color: #d01040 } /* Literal.String.Doc */
+.highlighter-rouge .s2 { color: #d01040 } /* Literal.String.Double */
+.highlighter-rouge .se { color: #d01040 } /* Literal.String.Escape */
+.highlighter-rouge .sh { color: #d01040 } /* Literal.String.Heredoc */
+.highlighter-rouge .si { color: #d01040 } /* Literal.String.Interpol */
+.highlighter-rouge .sx { color: #d01040 } /* Literal.String.Other */
+.highlighter-rouge .sr { color: #009926 } /* Literal.String.Regex */
+.highlighter-rouge .s1 { color: #d01040 } /* Literal.String.Single */
+.highlighter-rouge .ss { color: #990073 } /* Literal.String.Symbol */
+.highlighter-rouge .bp { color: #999999 } /* Name.Builtin.Pseudo */
+.highlighter-rouge .vc { color: #008080 } /* Name.Variable.Class */
+.highlighter-rouge .vg { color: #008080 } /* Name.Variable.Global */
+.highlighter-rouge .vi { color: #008080 } /* Name.Variable.Instance */
+.highlighter-rouge .il { color: #009999 } /* Literal.Number.Integer.Long */

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -644,6 +644,22 @@ a[id]{
 	clear: none;
 }
 
+.highlighter-rouge pre{
+  background: #f0f0f0;
+  overflow-x: scroll;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.highlighter-rouge code{
+  font-weight: inherit;
+  color: black;
+  border: none;
+  background: inherit;
+  position: static;
+  padding: 0;
+}
+
 .page aside{
 	font-size: 16px;
 	color: #918c84;


### PR DESCRIPTION
This attempts to fix #145 by adding rouge syntax highlighting CSS and better styling for `<pre>`:

<img width="655" alt="screen shot 2016-09-22 at 6 57 35 pm" src="https://cloud.githubusercontent.com/assets/124687/18769862/7322a0d8-80f6-11e6-8ae6-01689a173d1d.png">
