### PR TITLE
Add further reading on voice and tone page

### DIFF
--- a/_pages/our-style/voice-and-tone.md
+++ b/_pages/our-style/voice-and-tone.md
@@ -81,6 +81,14 @@ Let’s consider three examples that target three different reader groups. Obitu
         <td>Enthusiastic, earnest, bubbly</td>
         <td>“Say ‘I do!’ to 25% off. Now through July 3rd, take an additional 25% off all bridal wear and accessories. Celebrate your big day in style (and get a jumpstart on your honeymoon fund!).”</td>
     </tr>
-   </table>
+</table>
 
 If you’re having trouble finding an appropriate tone, try reframing the situation: How would you talk to a friend who’s in the same situation as your target user? Remembering that written communication is a conversation can help you settle on the best tone for your purpose.
+
+## Further reading
+
+* **[MailChimp’s voice and tone guide](http://voiceandtone.com/)**: This beautifully designed tool allows you to select different content types and learn more about what the user might be feeling while reading them, along with examples of tones appropriate to those content types. Super simple to use, this is a great quick reference for creating diverse types of content.
+* **[The nonviolent communication (NVC) framework for feelings](http://thrivinglifenvc.org/feelings)**: Pinpointing the most appropriate tone for a piece of content starts with identifying what your readers might be feeling when they read that content. This list of feelings is broken into two categories — feelings you experience when your needs are being met and when they aren’t. 
+* **[Jeff Goins’ voice activities](http://goinswriter.com/writing-voice/)**: Use author Jeff Goins’ ten-step exercise to pinpoint your authorial voice. The “steps” are actually discrete activities and can be undertaken in any order.
+* If you’re still a little confused about voice and tone, **[Wheaton College](http://www.wheaton.edu/Academics/Services/Writing-Center/Writing-Resources/Style-Diction-Tone-and-Voice)** provides an excellent breakdown of those — and more — writing components. 
+* **[Fast Company](http://www.fastcompany.com/3029356/work-smart/the-best-examples-questions-and-guides-to-find-your-social-media-marketing-voice)** has also weighed in on the voice and tone discussion.


### PR DESCRIPTION
In reviewing #163, we found that the only content in the voice and tone tutorial site that wasn't already in the content guide was the "further reading" section. I've moved that to the "voice and tone" page, as it doesn't quite match the style of our higher-level "resources" section, but is super helpful for people who are learning about voice and tone.