### PR TITLE
Update README.md install instructions, add Docker support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.3
+
+# jekyll_pages_api_search needs Node, so we gotta install it.
+
+# https://nodejs.org/en/download/package-manager/
+
+RUN apt-get update && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y nodejs zip

--- a/README.md
+++ b/README.md
@@ -26,12 +26,33 @@ We started by adapting [GOV.UK’s work](https://www.gov.uk/guidance/content-des
 
 ### Running the site
 
-The 18F Content Guide runs on [Jekyll](http://jekyllrb.com/). To run it locally:
+The 18F Content Guide runs on [Jekyll](http://jekyllrb.com/).
 
+To run it locally:
+
+1. Make sure that you have Ruby 2.3. At present, this project is incompatible with Ruby 2.4.
 1. Clone the repository.
-1. Get [Jekyll] and the necessary dependencies: `bundle install`
+1. Get [Jekyll][] and the necessary dependencies: `bundle install`
 1. Run the web server with `./go serve` (or `jekyll serve` if you have Jekyll installed globally)
 1. Visit the local site at [http://localhost:4000](http://localhost:4000)
+
+Note that you will also need [Node.js][] in order for the site's built-in
+search functionality to work. If you don't have it, that's ok--the search
+functionality won't work for you, though.
+
+### Running the site with Docker
+
+If you don't want to have to deal with making sure that you have the
+proper version of Ruby and Node installed, you can use Docker instead. It
+takes care of all the dependencies for you.
+
+1. Install [Docker][].
+1. Clone the repository.
+1. Run `docker-compose up`.
+1. Visit the local site at [http://localhost:4000](http://localhost:4000)
+
+If you ever decide that you no longer want to use Docker, run
+`docker-compose down -v` to properly clean everything up.
 
 ### Public domain
 
@@ -40,3 +61,7 @@ This project is in the worldwide [public domain](LICENSE.md).
 > As a work of the United States government, this project is in the public domain within the United States.
 
 > Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+
+[Jekyll]: http://jekyllrb.com/
+[Node.js]: https://nodejs.org/en/
+[Docker]: https://www.docker.com/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you don't want to have to deal with making sure that you have the
 proper version of Ruby and Node installed, you can use Docker instead. It
 takes care of all the dependencies for you.
 
-1. Install [Docker][].
+1. Install [Docker Community Edition][].
 1. Clone the repository.
 1. Run `docker-compose up`.
 1. Visit the local site at [http://localhost:4000](http://localhost:4000)
@@ -64,4 +64,4 @@ This project is in the worldwide [public domain](LICENSE.md).
 
 [Jekyll]: http://jekyllrb.com/
 [Node.js]: https://nodejs.org/en/
-[Docker]: https://www.docker.com/
+[Docker Community Edition]: https://www.docker.com/community-edition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  app:
+    build: .
+    working_dir: /content-guide
+    command: bash -c 'bundle install && jekyll serve --force_polling -H 0.0.0.0 -P 4000'
+    stop_signal: SIGKILL
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/content-guide
+      - root:/root/
+      - bundle:/usr/local/bundle/
+volumes:
+  root:
+  bundle:


### PR DESCRIPTION
This updates the `README.md` with the following info for normal development flows:

* Ruby 2.4 doesn't work with this project; apparently one of our dependencies uses a version of the [`json`](https://github.com/flori/json) gem that isn't compatible with 2.4 (see https://github.com/flori/json/issues/286 for more details). We could probably fix our `Gemfile` to make it work with 2.4 somehow, but for now I figured I'd just write a disclaimer to use Ruby 2.3.
* Node is actually required for [jekyll_pages_api_search](https://github.com/18F/jekyll_pages_api_search) to work. Fortunately, the site somewhat gracefully degrades to not support search if Node can't be found, rather than crashing.

This PR also adds a [Docker](https://www.docker.com/) setup so that folks who don't want to deal with installing the right version of Ruby and Node can just `docker-compose up` and go.
