### PR TITLE
Remove excerpt from index

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,8 +1,7 @@
 ---
 permalink: /
 title: Introduction
-layout: none   
-excerpt: none
+layout: none
 ---
 
 <html lang="en">


### PR DESCRIPTION
Fixes #200

Removes `excerpt: none` from index front matter to fall back on `site.description`.