### PR TITLE
Breaks URLs (`code` element) at container width

### DIFF
--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -125,6 +125,12 @@ pre {
   white-space: pre-wrap;
 }
 
+// Breaks urls at container width
+code {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
 // Show Slack icon before Slack Links
 a[href^="https://gsa-tts.slack.com"]::before {
   content: "";


### PR DESCRIPTION
Fixes #252 

[PREVIEW](https://federalist-de5c0cb8-65b2-45b8-bcc6-6fd137e9b755.app.cloud.gov/preview/18f/content-guide/overflow-breaks/our-style/urls-and-filenames/#examples)

- Adds CSS to break code lines at container width to prevent cropping

## Production
![url path examples with first two examples cropped on right side of screen](https://user-images.githubusercontent.com/32855580/99448131-41613700-28d4-11eb-9418-49ef80f25ebd.png)

## This PR
![url path examples that wrap to the next line](https://user-images.githubusercontent.com/32855580/99448725-6f467b80-28d4-11eb-99d4-4a3187d3c648.png)
