### PR TITLE
Remove deprecated link

### DIFF
--- a/_pages/our-style/capitalization.md
+++ b/_pages/our-style/capitalization.md
@@ -38,5 +38,3 @@ Headlines, page titles, subheads and similar content should follow sentence case
 > _Making sense of Washington’s tech landscape_  
 
 > _Privileges and responsibilities_
-
-See also: information about [optimizing headings]({{ "/content-types/headings-and-titles/" | relative_url }}).


### PR DESCRIPTION
Fixes #258

We removed the `content-types` section, so this link results in a 404 now. This change removes the link.