### PR TITLE
Update footer and add 18F logo

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -18,6 +18,10 @@ usa_banner: true
 # https://designsystem.digital.gov/components/headers/
 type: extended
 
+logo:
+  src: /images/18f-logo-black.svg
+  alt: 18F
+  
 # this is a key into _data/navigation.yml
 primary:
   links: primary

--- a/_data/usa_identifier.yaml
+++ b/_data/usa_identifier.yaml
@@ -1,11 +1,12 @@
 # Anchor component data
+# Anchor component data
 # See usa_anchor.html for the template
 
-anchor_data:
+identifier_data:
   - site_name: 18F Content Guide
     site_email: 18F@gsa.gov
-    site_url: https://derisking-guide.18f.gsa.gov
-    site_about: https://derisking-guide.18f.gsa.gov
+    site_url: https://content-guide.18f.gov
+    site_about: https://content-guide.18f.gov
     agency: U.S. General Services Administration
     agency_acronym: GSA
     agency_logo: gsa-logo-blue.svg

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -23,7 +23,7 @@
               alt="{{ header.logo.alt }}">
           {% endif %}
           <em class="usa-logo__text">
-            {{ header.title | default: site.title }}
+             Content Guide
           </em>
         </a>
       </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,64 +1,57 @@
-{% assign anchor = site.data.usa_anchor.anchor_data[0] %}
-<section class="anchor" data-uswds="1.0">
-<div class="component-anchor">
-  <div class="usa-accordion">
-    <div class="grid-container grid-container-desktop">
-      <div class="grid-row tablet:grid-gap-4">
-        <div class="grid-col-12">
-          <div class="org-short">
-            <div class="org-copy">
-              <a href="{{ anchor.agency_url }}" title="{{ anchor.agency }}">
-                <img src="{{site.baseurl}}/images/{{ anchor.agency_logo }}" class="org-img" alt="{{ anchor.agency }} Logo"></a>
-              <a href="{{ anchor.org_secondary_url }}" title="{{ anchor.org_secondary }}">
-                <img src="{{site.baseurl}}/images/{{ anchor.org_secondary_logo }}" class="org-img" alt="{{ anchor.org_secondary }} Logo"></a>
-              <p><a href="{{site.baseurl}}" title="{{ anchor.site_name }}">{{ anchor.site_name -}}</a> is a product of {{ anchor.agency_acronym }}&#8217;s <a href="{{ anchor.org_primary_url }}" title="{{ anchor.org_primary }}">{{ anchor.org_primary }}</a>{%if anchor.org_primary %}, and is managed by <a href="{{ anchor.org_secondary_url }}" title="{{ anchor.org_secondary }}">{{ anchor.org_secondary }}</a>{%endif%}.</p>
-            </div>
-            <button class="btn-learn-more usa-button usa-button--outline usa-button--inverse usa-accordion__button" aria-hidden="false" aria-expanded="false" aria-controls="org-details">
-              <span>Learn&nbsp;more</span>
-            </button>
-          </div>
-        </div>
+{% assign identifier = site.data.usa_identifier.identifier_data[0] %}
+<div class="usa-identifier">
+  <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
+    <div class="usa-identifier__container">
+      <div class="usa-identifier__logos">
+        <a href="https://www.gsa.gov/" class="usa-identifier__logo">
+          <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/images/{{ identifier.agency_logo }}" alt="GSA logo" role="img" />
+        </a>
       </div>
-      <div class="org-expanded" id="org-details" hidden>
-        <div class="grid-row tablet:grid-gap-2">
-          <div class="grid-col-12 tablet:grid-col-6">
-            <div class="org-copy">
-              {% if anchor.org_primary_bio %}
-                <p>{{ anchor.org_primary_bio }} <a class="more" href="{{ anchor.org_primary_url }}" title="Learn more about {{ anchor.org_primary }}">Read more about TTS</a>.</p>
-              {%endif %}
-              {% if .org_secondary_bio %}
-                <p>{{ anchor.org_secondary_bio }} <a class="more" href="{{ anchor.org_secondary_url }}" title="Learn more about {{ anchor.org_secondary }}">Read more</a></p>
-              {% endif %}
-            </div>
-          </div>
-          <div class="grid-col-12 tablet-lg:grid-col-5 tablet-lg:grid-offset-1">
-            <div class="org-links">
-              <p><i class="fas fa-envelope"></i> For questions about this website, email <a href="mailto:{{ anchor.site_email }}">{{ anchor.site_email }}</a>.</p>
-              <p>Additional information about the {{ anchor.agency }} ({{ anchor.agency_acronym }}) can be found at <a href="{{ anchor.agency_about_url }}" title="More about the {{ anchor.agency_acronym }}">{{ anchor.agency_about_url }}</a></p>
-              <ul>
-                <li><a href="{{ anchor.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">Report fraud, waste, or abuse to the Office of the Inspector General</a></li>
-                <li><a href="{{ anchor.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">Submit a Freedom of Information Act (FOIA) request</a></li>
-                <li><a href="{{ anchor.budget_performance_url }}" title="View budget and performance reports">View budget and performance reports</a></li>
-                <li><a href="{{ anchor.accessibility_url }}" title="View accessibility statement">View accessibility statement</a></li>
-                <li><a href="{{ anchor.no_fear_act_url }}" title="View No FEAR Act data">View No FEAR Act data</a></li>
-              </ul>
-            </div>
-          </div>
-        </div>
+      <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
+        <p class="usa-identifier__identity-domain">18F Content Guide</p>
+        <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
+          <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">
+            GSA’s Technology Transformation Services
+          </a>
+        </p>
       </div>
     </div>
-  </div>
-</div>
-<div class="component-anchor-support">
-  <div class="grid-container grid-container-desktop">
-    <div class="grid-row tablet-lg:grid-gap-2">
-      <div class="grid-col-12">
-        <div class="usagov">
-          <span>Looking for U.S. government information and services?</span></p>
-          <a class="usa-link usagov__link" href="{{ anchor.usagov_contact_url }}?ref={{ anchor.site_name }}">Visit USA.gov</a>
-        </div>
-      </div>
+  </section>
+  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
+    <div class="usa-identifier__container">
+      <ul class="usa-identifier__required-links-list">
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">
+            Report fraud, waste, or abuse to the Office of the Inspector General
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
+            Submit a Freedom of Information Act (FOIA) request
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
+            View budget and performance reports
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.accessibility_url }}" title="View accessibility statement">
+            View accessibility statement
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
+            View No FEAR Act data
+          </a>
+        </li>
+      </ul>
     </div>
-  </div>
+  </nav>
+  <section class="usa-identifier__section usa-identifier__section--usagov" aria-label="U.S. government information and services">
+    <div class="usa-identifier__container">
+      <div class="usa-identifier__usagov-description text-base-lightest">Looking for U.S. government information and services?</div>
+      <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+    </div>
+  </section>
 </div>
-</section>

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -19,6 +19,8 @@ $color-gray-divider:  color("gray-20");
 
 $color-gray-border:   color("base-dark");
 
+$logo-size-lg: 3rem;
+$logo-size-md: 2rem;
 
 // Typography
 .usa-prose{
@@ -74,6 +76,25 @@ a:hover {
 
 .usa-nav__secondary-links {
   display: none;
+}
+
+.usa-header.usa-header--extended .usa-logo-img {
+  height: $logo-size-md;
+}
+
+.usa-logo__text {
+  line-height: $logo-size-md;
+}
+
+
+@include at-media('desktop') {
+  .usa-header.usa-header--extended .usa-logo-img {
+    height: $logo-size-lg;
+  }
+
+  .usa-logo__text {
+    line-height: $logo-size-lg;
+  }
 }
 
 // usa-sidenav
@@ -201,5 +222,3 @@ a[href^="https://gsa-tts.slack.com"]::before {
     min-height: 100vh;
   }
 }
-
-@import '_usa_anchor';


### PR DESCRIPTION
This PR updates the footer to use the published USWDS `identifier` component in place of the earlier `anchor` version. We are trying to make this consistent across all of the 18F guides and sites.

Since the default version shows only one logo, the PR also adds the 18F logo to the header

👓 &nbsp;[Preview](https://federalist-de5c0cb8-65b2-45b8-bcc6-6fd137e9b755.app.cloud.gov/preview/18f/content-guide/ik-update-footer/)