### PR TITLE
Adds missing h2 partial to side nav

### DIFF
--- a/_pages/our-style/punctuation.md
+++ b/_pages/our-style/punctuation.md
@@ -8,6 +8,8 @@ subnav:
     href: '#bulleted-lists'
   - text: Colons
     href: '#colons'
+  - text: Commas
+    href: '#commas'  
   - text: Dashes
     href: '#dashes'
   - text: Quotes


### PR DESCRIPTION
We're missing side nav for `Commas` on the `Our style` page, which means 🚨  we're missing the in-page link to the section that covers the serial/Oxford comma 🚨.