### PR TITLE
Fixes SEO / accessibility error in secondary nav

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -27,5 +27,5 @@ primary:
   links: primary
 
 # this is a key into _data/navigation.yml
-secondary:
-  links: secondary
+#secondary:
+#  links: secondary

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -133,9 +133,10 @@
 
           {% if header.type == 'extended' or header.type == 'extended-mega' %}
           {% assign _secondary = header.secondary %}
+          {% assign secondary_links = site.data.navigation[_secondary.links] | default: _secondary.links %}
           <div class="usa-nav__secondary">
+            {% if secondary_links %}
             <ul class="usa-unstyled-list usa-nav__secondary-links">
-              {% assign secondary_links = site.data.navigation[_secondary.links] | default: _secondary.links %}
               {% for _link in secondary_links %}
                 <li class="usa-nav__secondary-item">
                   <a href="{% if _link.external %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}"
@@ -145,6 +146,7 @@
                 </li>
               {% endfor %}
             </ul>
+           {% endif %} 
             {% if site.search_site_handle  %}
               <form
                 accept-charset="UTF-8"


### PR DESCRIPTION
I noticed via Lighthouse audit that the guide is generating an empty anchor link in the secondary navigation. Lighthouse described this as an SEO error, but it's also an accessibility problem (screen readers will parse the empty anchor).

![Lighthouse audit showing 92 score for SEO, with links uncrawlable](https://user-images.githubusercontent.com/32855580/176516292-853454bb-bb35-45a5-9313-6dca05a4506f.png)

```
<ul class="usa-unstyled-list usa-nav__secondary-links">
    <li class="usa-nav__secondary-item">
      <a href="">
      </a>
    </li>
</ul>
```

There is no data for the secondary nav, and it is set by default to `display: none` in the stylesheet. But it shows up as an empty anchor in the DOM, which screen readers will still parse.

This PR prevents Jekyll from generating an empty anchor element.

![Lighthouse SEO score showing 100](https://user-images.githubusercontent.com/32855580/176517067-6c31d093-99d4-4e1b-a01e-193e47f1b60a.png)
